### PR TITLE
Fix issues with current working directory flag

### DIFF
--- a/terminhtml/cli.py
+++ b/terminhtml/cli.py
@@ -51,7 +51,7 @@ def run_commands_create_html(
     cwd: Optional[Path] = typer.Option(
         None,
         "--cwd",
-        "-c",
+        "-d",
         help="Working directory to run commands in. "
         "If not passed, defaults to a temporary directory.",
     ),

--- a/terminhtml/runner/main.py
+++ b/terminhtml/runner/main.py
@@ -76,10 +76,11 @@ def run_commands(
 
     input = input or []
     orig_dir = os.getcwd()
+    absolute_cwd = cwd.absolute() if cwd else None
     with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)
-        if cwd:
-            begin_cwd = cwd
+        if absolute_cwd:
+            begin_cwd = absolute_cwd
         else:
             begin_cwd = Path(tmpdir)
         last_context = RunnerContext(cwd=begin_cwd)

--- a/tests/dirutils.py
+++ b/tests/dirutils.py
@@ -1,0 +1,11 @@
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def change_directory_to(path: Path):
+    current_path = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(current_path)

--- a/tests/e2e/test_cwd.py
+++ b/tests/e2e/test_cwd.py
@@ -1,0 +1,30 @@
+import pytest
+
+from tests.config import INPUT_FILES_DIR
+from tests.dirutils import change_directory_to
+from tests.e2e.cli_stub import run_cli
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["-d", "--cwd"],
+)
+def test_command_runs_in_absolute_cwd_when_passed(flag: str):
+    cwd = INPUT_FILES_DIR
+    result = run_cli(f"{flag} {cwd.absolute()} 'ls -l'")
+    text = result.output
+    assert result.exit_code == 0
+    assert "rich_progress_bar.html" in text
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["-d", "--cwd"],
+)
+def test_command_runs_in_current_directory_when_passed_as_dot(flag: str):
+    cwd = INPUT_FILES_DIR
+    with change_directory_to(cwd):
+        result = run_cli(f"{flag} . 'ls -l'")
+        text = result.output
+        assert result.exit_code == 0
+        assert "rich_progress_bar.html" in text


### PR DESCRIPTION
## What

- Changes the short flag from `-c` to `-d` for current working directory as `-c` is already taken (fixes #12)
- Makes it take the absolute path before resolving the directory, so that relative paths are resolved relative to the directory for the running process, rather than the temp directory  (fixes #13)
- Adds e2e tests for cwd workflows